### PR TITLE
Obfuscate e-mail address

### DIFF
--- a/script.js
+++ b/script.js
@@ -201,8 +201,8 @@ const menu = {
 const contact = {
     mail: {
         a: document.getElementsByClassName('link_mail'),
-        value: 'doronyong94@gmail.com',
-        href: 'mailto:doronyong94@gmail.com'
+        value: 'doro' + 'nyong' + '94' + '\u0040' + 'gmail' + '.com',
+        href: 'mailto' + ':doro' + 'nyong' + '94' + '\u0040' + 'gmail' + '.com'
     },
     twitter: {
         a: document.getElementsByClassName('link_twitter'),


### PR DESCRIPTION
이메일 스패밍 방지를 위해 이메일 주소를 하나의 합쳐진 string으로 표현하는 것은 지양해야합니다.  
알파벳과 기호 문자 모두를 유니코드 코드로 표현하는 방법(\uXXXX)도 있는데 소스 코드 가독성이 심히 뭐시기해지므로(...) 골뱅이 문자를 제외한 다른 문자들은 놔두고 string 분리 후 합치는 방식입니다.